### PR TITLE
Add MadeOnSol

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,8 @@ https://solblaze.org/restart
 Solana Floor domains
 https://solanafloor.com/domains
 
+MadeOnSol - Solana ecosystem directory with 815+ tools, deployer tracking, and KOL wallet monitoring https://madeonsol.com
+
 
 
 ------------------------


### PR DESCRIPTION
Adding MadeOnSol (madeonsol.com) — a Solana ecosystem directory with 815+ curated tools across 26 categories, plus free deployer tracking (7,197+ pump.fun deployers) and KOL wallet monitoring (462 wallets).